### PR TITLE
Add static link parameter

### DIFF
--- a/Parameters/CodableParameter.swift
+++ b/Parameters/CodableParameter.swift
@@ -46,6 +46,8 @@ public class CodableParameter: Codable {
             value = try container.decode(StaticTextParameter.self, forKey: .value)
         case .picker:
             value = try container.decode(PickerParameter.self, forKey: .value)
+        case .staticLink:
+            value = try container.decode(StaticLinkParameter.self, forKey: .value)
         case .none:
             value = BoolParameter()
         }
@@ -71,6 +73,8 @@ public class CodableParameter: Codable {
             try container.encode(value as! StaticTextParameter, forKey: .value)
         case .picker:
             try container.encode(value as! PickerParameter, forKey: .value)
+        case .staticLink:
+            try container.encode(value as! StaticLinkParameter, forKey: .value)
         }
     }
 }

--- a/Parameters/Parameter.swift
+++ b/Parameters/Parameter.swift
@@ -120,6 +120,7 @@ public enum ParameterDataType: Int, Codable {
     case segmented = 5
     case staticText = 6
     case picker = 7
+    case staticLink = 8
 }
 
 public protocol Parameter {
@@ -761,4 +762,57 @@ public class StaticTextParameter: BaseParameter, Parameter, Codable {
 
     public func revertToDefault() {
     }
+}
+
+public class StaticLinkParameter: BaseParameter, Parameter, Codable {
+
+    public var uuid: String { return category + "-" + name }
+    public var dataType: ParameterDataType = .staticLink
+    public var persisted: Bool = true
+    public var category: String = ""
+    public var name: String = ""
+    public var isNumeric: Bool = false
+    public var url: String = "" {
+        didSet {
+            guard oldValue != url else { return }
+            observers.forEach { (observer) in
+                observer.didUpdate(parameter: self)
+            }
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case uuid
+        case dataType
+        case category
+        case name
+        case url
+    }
+
+    override public init() {
+        super.init()
+        revertToDefault()
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.dataType = .staticLink
+        self.category = try container.decode(String.self, forKey: .category)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.url = try container.decode(String.self, forKey: .url)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        guard persisted == true else { return }
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(uuid, forKey: .uuid)
+        try container.encode(dataType.rawValue, forKey: .dataType)
+        try container.encode(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(url, forKey: .url)
+    }
+
+    public func revertToDefault() {
+    }
+
 }

--- a/Parameters/ParametersViewController.swift
+++ b/Parameters/ParametersViewController.swift
@@ -166,6 +166,12 @@ public class ParametersViewController: UIViewController, UITableViewDataSource, 
                     cell = staticTextParameterCellView
 
                     return cell
+                } else if let staticLinkPref = parameter as? StaticLinkParameter {
+                    cell = tableView.dequeueReusableCell(withIdentifier: "StaticLinkParameterCell", for: indexPath)
+                    cell.textLabel?.text = staticLinkPref.name
+                    cell.accessoryType = .disclosureIndicator
+
+                    return cell
                 }
             }
         }
@@ -235,6 +241,13 @@ public class ParametersViewController: UIViewController, UITableViewDataSource, 
 
         tableView.deselectRow(at: indexPath, animated: true)
 
+        if let category = parameterCategory(for: indexPath),
+           category.disclosed == true,
+           let staticLinkPref = category.entries[indexPath.row] as? StaticLinkParameter,
+           let url = URL(string: staticLinkPref.url) {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+
         // push on a VC for this parameter set
         if let category = parameterCategory(for: indexPath), category.disclosed == false {
             let parametersViewController = ParametersViewController()
@@ -291,6 +304,7 @@ public class ParametersViewController: UIViewController, UITableViewDataSource, 
         tableView.register(SegmentedParameterCellView.self, forCellReuseIdentifier: "SegmentedParameterCell")
         tableView.register(PickerParameterCellView.self, forCellReuseIdentifier: "PickerParameterCell")
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "ParameterCategoryCell")
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "StaticLinkParameterCell")
 
         startObservingKeyboardEvents()
     }


### PR DESCRIPTION
Here is an implementation of button-like parameters that open links set in `url` property.
I'm not quite sure about the name of this property. All other parameters use `value`, but for links, it seems unclear that value should contain URL.

This solution can be generalized to in-app button handler with deep link as URL.